### PR TITLE
Corrected wadl:resources/@base in RestXqWadl

### DIFF
--- a/basex-api/src/main/java/org/basex/http/restxq/RestXqWadl.java
+++ b/basex-api/src/main/java/org/basex/http/restxq/RestXqWadl.java
@@ -44,7 +44,7 @@ public final class RestXqWadl {
   public synchronized FElem create(final HashMap<String, WebModule> modules) {
     // create root nodes
     final FElem application = new FElem(WADL + "application", WADL_URI).declareNS();
-    final String base = req.getRequestURL().toString();
+    final String base = req.getRequestURL().toString().replace(req.getRequestURI(), req.getContextPath());
     final FElem resources = elem("resources", application).add("base", base);
 
     // create children


### PR DESCRIPTION
In the wadl generated by the rest:wadl() function, we noticed that the wadl:resources/@base contains redundant prefix that clashed with the resource/@path. This issue emerged while importing the resulting wadl into tools such as Postman. The proposed pull request should fix it in all cases, including deployment in application containers such as Tomcat (where there is a context path too).